### PR TITLE
fix(MoP): add ExpertiseRatingShorter to Localization.lua and TooltipParsing.lua to fix missing regex pattern

### DIFF
--- a/Localization.lua
+++ b/Localization.lua
@@ -557,6 +557,7 @@ PawnLocal.TooltipParsing = {
 	["ExpertiseClassic"] = "^Equip: Reduces the chance for your attacks to be dodged or parried by #%%%.$",
 	["ExpertiseRating"] = "^Equip: Increases your expertise rating by #%.$",
 	["ExpertiseRatingShort"] = "^%+?# Expertise Rating$",
+	["ExpertiseRatingShorter"] = "^%+?# Expertise$",
 	["FeralAp"] = "^Equip: %+# Attack Power in Cat, Bear, and Dire Bear forms only%.$",
 	["FeralApMoonkin"] = "^Equip: Increases attack power by # in Cat, Bear, Dire Bear, and Moonkin forms only%.$",
 	["FeralApWrath"] = "^Increases attack power by # in Cat, Bear, Dire Bear, and Moonkin forms only%.$",

--- a/TooltipParsing.lua
+++ b/TooltipParsing.lua
@@ -256,6 +256,7 @@ PawnRegexes =
 	{L.SpellHitRatingShort, "SpellHitRating"}, -- Burning Crusade, https://tbc.wowhead.com/item=31861/great-dawnstone
 	{L.ExpertiseRating, "ExpertiseRating"}, -- Burning Crusade, /pawn compare 19351
 	{L.ExpertiseRatingShort, "ExpertiseRating"}, -- Wrath, Precise Bloodstone
+	{L.ExpertiseRatingShorter, "ExpertiseRating"}, -- Mists of Pandaria, /pawn compare 90862
 	{L.ExpertiseClassic, "ExpertiseRating"}, -- Classic SoD, /pawn compare 236019
 	{L.ArmorPenetration, "ArmorPenetration"},
 	{L.ArmorPenetrationRating, "ArmorPenetration"}, -- Burning Crusade, /pawn compare 34703


### PR DESCRIPTION
Adds missing ExpertiseRatingShorter regex to Localization.lua and TooltipParsing.lua to restore parsing in MoP Classic.